### PR TITLE
Added a trim-call to fix strange jQuery behaviour.

### DIFF
--- a/dashboard/PlayerTimerDashboard.js
+++ b/dashboard/PlayerTimerDashboard.js
@@ -287,7 +287,7 @@ $(function () {
 
     function OnPlay() {
         var options = {};
-        if ($('#play').text() === "play") {
+        if ($('#play').text().trim() === "play") {
             $("#reset").button({
                 disabled: true
             });


### PR DESCRIPTION
I noticed that at least for me, the jQuery function text() returned a string with a extra space before the actual text (as reported by .innerText() for example).

This messed up the control-flow in the if-statement where determining the current function of the play-button, resulting in being unable to start the run, since it believed the button to be a pause-button.

I have fixed it by trimming the string, to remove extra spaces.