### PR TITLE
Fixes to the ESAController API before ESA2016

### DIFF
--- a/extension/esacontroller.js
+++ b/extension/esacontroller.js
@@ -13,7 +13,8 @@ function register_api(nodecg) {
 
         //Get all finished players
         nodecg.readReplicant("finishedTimers").forEach(function(timer) {
-            result[name] = "finished";
+            if (timer.time != '00:00:00')
+                result[timer.name] = "finished";
         })
 
         res.status(200).json(result);
@@ -74,10 +75,11 @@ function publish(event) {
 }
 
 module.exports = function (nodecg) {
+    console.log("ESACONTROLLER!");
     _nodecg = nodecg;
     
-    if (nodecg.bundleConfig !== undefined && 
-        nodecg.bundleConfig.api !== undefined && 
+    if (nodecg.bundleConfig !== 'undefined' && 
+        nodecg.bundleConfig.api !== 'undefined' && 
         nodecg.bundleConfig.api.enable) {
         register_api(nodecg)
     }

--- a/extension/esacontroller.js
+++ b/extension/esacontroller.js
@@ -68,7 +68,11 @@ function publish(event) {
     if (_nodecg.bundleConfig.api.hooks) {
         _nodecg.bundleConfig.api.hooks.forEach(function(sub) {
             request.post(sub, {json: event, timeout: 1500}, function(err) {
-                _nodecg.log.error("Error publishing event " + event.event + " to " + sub + ".", err);
+                if (err) {
+                    _nodecg.log.error(
+                        "Error publishing event " + event.event + " to " + sub + ".", 
+                        err);
+                }
             })
         });
     }

--- a/extension/esacontroller.js
+++ b/extension/esacontroller.js
@@ -79,11 +79,10 @@ function publish(event) {
 }
 
 module.exports = function (nodecg) {
-    console.log("ESACONTROLLER!");
     _nodecg = nodecg;
     
-    if (nodecg.bundleConfig !== 'undefined' && 
-        nodecg.bundleConfig.api !== 'undefined' && 
+    if (typeof(nodecg.bundleConfig) !== 'undefined' && 
+        typeof(nodecg.bundleConfig.api) !== 'undefined' && 
         nodecg.bundleConfig.api.enable) {
         register_api(nodecg)
     }

--- a/extension/esacontroller.js
+++ b/extension/esacontroller.js
@@ -6,15 +6,18 @@ var _nodecg;
 
 function register_api(nodecg) {
     app.get("/speedcontrol/timers", function(req, res) {
-        var result = {}
-        nodecg.readReplicant("runDataActiveRunRunnerList").forEach(function(runner) {
-            result[runner.names.international] = "running"; //Assume running.
-        })
+        var result = []
+        nodecg.readReplicant("runDataActiveRunRunnerList").forEach(function(runner, i) {
+            result[i] = {
+                name: runner.names.international,
+                status: "running"
+            };
+        });
 
         //Get all finished players
-        nodecg.readReplicant("finishedTimers").forEach(function(timer) {
+        nodecg.readReplicant("finishedTimers").forEach(function(timer, i) {
             if (timer.time != '00:00:00')
-                result[timer.name] = "finished";
+                result[i].status = "finished";
         })
 
         res.status(200).json(result);

--- a/extension/esacontroller.js
+++ b/extension/esacontroller.js
@@ -10,14 +10,28 @@ function register_api(nodecg) {
         nodecg.readReplicant("runDataActiveRunRunnerList").forEach(function(runner, i) {
             result[i] = {
                 name: runner.names.international,
-                status: "running"
+                status: "waiting"
             };
         });
 
+        const stopwatch = nodecg.readReplicant('stopwatches')[0]
+        console.log(stopwatch);
+        if (stopwatch.state == "running") {
+            result.forEach(function(runner) {
+                runner.status = "running";
+            });
+        }
+
         //Get all finished players
         nodecg.readReplicant("finishedTimers").forEach(function(timer, i) {
-            if (timer.time != '00:00:00')
-                result[i].status = "finished";
+            if (timer.time != '00:00:00') {
+                result.forEach(function(runner) {
+                    if (runner.name == timer.name) {
+                        runner.status = "finished";
+                    }
+                });
+            }
+                
         })
 
         res.status(200).json(result);


### PR DESCRIPTION
Once I actually started to use the API I added earlier, I realized that it had many flaws (probably still does).
The lack of security what so ever bothered me as well as the complete failure the GET /speedcontrol/timers was.

This is all my fixes to the API to make it work well with the ESAController to be deployed tomorrow evening at ESA2016.

Sorry for being out in the last minute.