### PR TITLE
Change to how twitch game name functions

### DIFF
--- a/READMES/SpeedcontrolConfiguration.md
+++ b/READMES/SpeedcontrolConfiguration.md
@@ -17,7 +17,9 @@ named the erroneous name of "nodecg-speedcontrol.json.txt". The file should cont
 {
     "live": true,
     "enableTwitchApi": true,
-    "user": "<twitchchannel>"
+    "user": "<twitchchannel>",
+	"streamTitle": "Game: {{game}} - Category: {{category}} - Players: {{players}}",
+	"defaultGame": "Retro"
 }
 ```
 
@@ -27,3 +29,7 @@ it's adviced that you add this configuration.
 If `"enableTwitchApi": true` is defined, automatical and manual sync to your configured user can be used from the Stream Control dashboard panel, otherwise this panel doesn't do anything!
 
 "user": must be defined if "enableTwitchApi" is defined, otherwise bundle doesn't know which user to update. e.g: `"user": "sethcharleon"`
+
+"streamtitle": Set this if you want speedcontrol to update your title on twitch, {{game}} {{category}} and {{players}} are all replaced with data from the current run
+
+"defaultGame": This is used if the twitch game name isn't found on speedrun.com. It's important you always use a directory game on twitch - Retro is a good catch all.

--- a/dashboard/RunPlayerDashboard.js
+++ b/dashboard/RunPlayerDashboard.js
@@ -153,11 +153,12 @@ $(function () {
             if(runDataArrayReplicantPlayer.value == "") {
                 return;
             }
-            var displayString = "Are you sure that you want to activate the run\n " + $(this).text().replace("Play ", "");
-            if (confirm(displayString)) {
-                nodecg.sendMessage("resetTime", 0);
-                runPlayer_playNextRun();
-            }
+		// Resets the timer
+		nodecg.sendMessage("resetTime", 0);
+		
+		// Loads the next run
+		runPlayer_playNextRun();
+
         });
 
 
@@ -242,17 +243,28 @@ $(function () {
             return;
         }
 
-
+			// Grabs game metadata from speedrun.com to help with updating twitch
 			getTwitchGameNameFromSRC(runData, function(twitchGameName) {
 	 			var requestObject = {};
 	 			requestObject.channel = {};
 
 	 			if (twitchGameName) {
+					// This is the Twitch Game Name field on speedrun.com. You need supermod to update them (or give Pac some love)
 	 				requestObject.channel.game = twitchGameName;
 	 			}
 
 	 			else {
-	 				requestObject.channel.game = runData.game;
+					// Fallback if none was found. Uses defaultGame in bundle config if available, otherwise hard coded default
+					if (nodecg.bundleConfig.defaultGame) {
+						console.log("No twitch game found on Speedrun.com - using default from configuration");
+						requestObject.channel.game = nodecg.bundleConfig.defaultGame;
+					} else {
+						console.log("No twitch game found on Speedrun.com - please set defaultGame in nodecg-speedcontrol.json");
+						requestObject.channel.game = "Retro";
+					}
+					
+					// Slightly different message to the operator as their concern is just to fix the immediate problem at hand
+					alert("Twitch game has been set to default - please log onto the twitch dashboard and update this manually");
 	 			}
 
 	 			// Gets Twitch channel names from the runData and puts them in an array to send to the FFZ WS script.
@@ -277,9 +289,6 @@ $(function () {
 	 			nodecg.sendMessage('updateFFZFollowing', twitchNames);
 	 			nodecg.sendMessage('updateChannel', requestObject);
 
-	 			if (!twitchGameName) {
-	 				alert("Game not found on speedrun.com, check that the game set on Twitch is a game available in the directory.");
-	 			}
 	 		});
     }
 


### PR DESCRIPTION
So testing the data for DHW I found it still undesirable that the old method just used the game name that was known not to exist on twitch. Instead, I've created a new config statement for a default game to use where none other exists.

Got rid of the 'next run' nagbox. I don't think it will be missed. I've also updated the readme to include this and streamTitle which was undocumented.