### PR TITLE
First implementation of Twitch Search API as backup

### DIFF
--- a/dashboard/RunPlayerDashboard.js
+++ b/dashboard/RunPlayerDashboard.js
@@ -11,7 +11,9 @@ $(function () {
     var runPlayer_activeRunObject = undefined;
     var syncGamePlayedToTwitch = false;
     var blankSlateRunContainerHtml = $('#run-player-container').html();
+	
     // Initialize replicants we will use
+ 
     var runDataArrayReplicantPlayer = nodecg.Replicant("runDataArray");
     runDataArrayReplicantPlayer.on("change", function (newValue, oldValue) {
         if (typeof newValue !== 'undefined' && newValue != "") {
@@ -232,67 +234,71 @@ $(function () {
         });
     }
 
-    function runPlayer_setTwitchChannelData(runData) {
-        if (!nodecg.bundleConfig || typeof nodecg.bundleConfig.user === 'undefined' || typeof nodecg.bundleConfig.enableTwitchApi === 'undefined') {
-            alert("If you want to use the twitch functionality, you need to create a file called nodecg-speedcontrol.json in nodecg/cfg and fill it with:\n" +
-                "{\n" +
-                "\"enableTwitchApi\": \"true\"," +
-                "\"user\": \"twitchusername\"\n" +
-                "}\n" +
-                "exchange username with the twitch username which you want to access");
-            return;
-        }
+	function runPlayer_setTwitchChannelData(runData) {
+		if (!nodecg.bundleConfig || typeof nodecg.bundleConfig.user === 'undefined' || typeof nodecg.bundleConfig.enableTwitchApi === 'undefined') {
+			alert("If you want to use the twitch functionality, you need to create a file called nodecg-speedcontrol.json in nodecg/cfg and fill it with:\n" +
+				"{\n" +
+				"\"enableTwitchApi\": \"true\"," +
+				"\"user\": \"twitchusername\"\n" +
+				"}\n" +
+				"exchange username with the twitch username which you want to access");
+			return;
+		}
 
-			// Grabs game metadata from speedrun.com to help with updating twitch
-			getTwitchGameNameFromSRC(runData, function(twitchGameName) {
-	 			var requestObject = {};
-	 			requestObject.channel = {};
-
-	 			if (twitchGameName) {
-					// This is the Twitch Game Name field on speedrun.com. You need supermod to update them (or give Pac some love)
-	 				requestObject.channel.game = twitchGameName;
-	 			}
-
-	 			else {
-					// Fallback if none was found. Uses defaultGame in bundle config if available, otherwise hard coded default
-					if (nodecg.bundleConfig.defaultGame) {
-						console.log("No twitch game found on Speedrun.com - using default from configuration");
-						requestObject.channel.game = nodecg.bundleConfig.defaultGame;
-					} else {
-						console.log("No twitch game found on Speedrun.com - please set defaultGame in nodecg-speedcontrol.json");
-						requestObject.channel.game = "Retro";
-					}
-					
-					// Slightly different message to the operator as their concern is just to fix the immediate problem at hand
-					alert("Twitch game has been set to default - please log onto the twitch dashboard and update this manually");
-	 			}
-
-	 			// Gets Twitch channel names from the runData and puts them in an array to send to the FFZ WS script.
-	 			var twitchNames = [];
-	 			var playerNames = [];
-	 			for (var i = 0; i < runData.players.length; i++) {
-					var twitchName = (runData.players[i].twitch) ? runData.players[i].twitch.uri.replace(/https?:\/\/.*?\//, '') : undefined;
-					if (twitchName && !twitchName.match(/^http/)) {
-						twitchNames.push(twitchName);
-					}
-					playerNames.push(runData.players[i].names.international);
-	 			}
-
-				if (nodecg.bundleConfig && typeof nodecg.bundleConfig.streamTitle !== 'undefined') {
-					var newTitle = nodecg.bundleConfig.streamTitle
-														.replace("{{game}}",runData.game)
-														.replace("{{players}}", playerNames.join(', '))
-														.replace("{{category}}", runData.category );
-					requestObject.channel.status = newTitle;
+		// Handles getting twitch directory metadata for the game
+		getTwitchGameName(runData, function(twitchGameName) {
+	 		var requestObject = {};
+	 		requestObject.channel = {};
+			
+			// Because this is a callback, the game name should have already been found (look at function (getTwitchGameName))
+	 		if (twitchGameName) {
+				requestObject.channel.game = twitchGameName;
+			} else {
+				// Fallback to config default. Uses defaultGame in bundle config if available, otherwise hard coded
+				if (nodecg.bundleConfig.defaultGame) {
+					console.log("No automatic game data found - using default from configuration");
+					requestObject.channel.game = nodecg.bundleConfig.defaultGame;
+				} else {
+					console.log("No automatic game data found - please set defaultGame in nodecg-speedcontrol.json");
+					requestObject.channel.game = "Retro";
 				}
-
-	 			nodecg.sendMessage('updateFFZFollowing', twitchNames);
-	 			nodecg.sendMessage('updateChannel', requestObject);
-
-	 		});
+				
+				// Alert the operator that a generic game name has been used
+				alert("Twitch game has been set to default - please log onto the twitch dashboard and update this manually");
+ 			}
+			
+	 		// Gets Twitch channel names from the runData and puts them in an array to send to the FFZ WS script.
+ 			var twitchNames = [];
+ 			var playerNames = [];
+ 			for (var i = 0; i < runData.players.length; i++) {
+				var twitchName = (runData.players[i].twitch) ? runData.players[i].twitch.uri.replace(/https?:\/\/.*?\//, '') : undefined;
+				if (twitchName && !twitchName.match(/^http/)) {
+					twitchNames.push(twitchName);
+				}
+				playerNames.push(runData.players[i].names.international);
+ 			}
+			if (nodecg.bundleConfig && typeof nodecg.bundleConfig.streamTitle !== 'undefined') {
+				var newTitle = nodecg.bundleConfig.streamTitle
+													.replace("{{game}}",runData.game)
+													.replace("{{players}}", playerNames.join(', '))
+													.replace("{{category}}", runData.category );
+				requestObject.channel.status = newTitle;
+			}
+			
+			// Fires off the arrays to the server to update FFZ and Twitch.
+	 		nodecg.sendMessage('updateFFZFollowing', twitchNames);
+ 			nodecg.sendMessage('updateChannel', requestObject);
+ 		});
     }
 
-		function getTwitchGameNameFromSRC(runData, callback) {
+	function getTwitchGameName(runData, callback) {
+		// This routine searches Speedrun.com then Twitch APIs for an accurate directory name for a game.
+		
+		// Step 1: Speedrun.com exact match
+		// This is the Twitch Game Name field on speedrun.com. You need supermod to update them (or give Pac some love)
+		
+		var twitchGameName;
+
   		$.ajax({
   			url: "https://www.speedrun.com/api/v1/games?name=" + runData.game + "&limit=1",
   			dataType: "jsonp",
@@ -300,18 +306,54 @@ $(function () {
   				q: runData.game
   			},
   			success: function(result) {
-  				var twitchGameName;
-
-    			if (result.data.length > 0) {
+				// We look for an exact match (case insensitive) here so games like super metroid fall back to twitch search instead
+    			if ((result.data.length > 0) && (runData.game.toLowerCase() == result.data[0].names.twitch.toLowerCase())) {
   					twitchGameName = result.data[0].names.twitch;
-  				}
+  				} else {
+					console.log ("No exact game match on speedrun.com for "+ runData.game);
+					twitchGameName = '';
+				}
 
-  				callback(twitchGameName);
+
   			},
   			error: function() {
-  				callback(undefined);
+  				console.log("Warning: Speedrun.com API call failed")
   			}
   		});
+		
+		// this is a dirty hard coded 1 second wait for SR.com data.
+		setTimeout(function(){
+			if (twitchGameName) { 
+				// If we found a result at step 1, call it back and stop  
+				console.log("Automatic game name data for "+ twitchGameName +" sourced from Speedrun.com API") 
+				callback(twitchGameName); 
+				return; 
+			 
+			} else { 
+				// Step 2: Twitch.
+				// APIV3 fuzzy search. Uses game name of first result.
+				// This is mostly a fallback to serve games like Super Metroid that aren't on SRcom at all.
+				// For this we strip out punctuation and anything between brackets for more hits
+				var string = runData.game;
+				var string = string.replace(/\s*\(.*?\)\s*/g, ''); // between brackets
+				var string = string.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g,""); // specified punctuation
+				var string = string.toLowerCase(); // like someone would type it manually
+				
+				console.log ("Twitch Search: " + string);
+				nodecg.sendMessage('twitchGameSearch', string, function(replyData) {
+					if (replyData) {
+						// Send it away!
+						console.log("Automatic game name data for "+ replyData +" sourced from Twitch API")
+						callback(replyData);
+						return;
+					} else {
+						// Sometimes there just isn't data :(
+						callback(undefined);
+						return;
+					}
+				});
+			}
+		},1000);
   	}
 
     function runPlayer_playNextRun() {

--- a/dashboard/RunPlayerDashboard.js
+++ b/dashboard/RunPlayerDashboard.js
@@ -307,7 +307,7 @@ $(function () {
   			},
   			success: function(result) {
 				// We look for an exact match (case insensitive) here so games like super metroid fall back to twitch search instead
-    			if ((result.data.length > 0) && (runData.game.toLowerCase() == result.data[0].names.twitch.toLowerCase())) {
+    			if ((result.data.length > 0) && (runData.game.toLowerCase() == result.data[0].names.international.toLowerCase())) {
   					twitchGameName = result.data[0].names.twitch;
   				} else {
 					console.log ("No exact game match on speedrun.com for "+ runData.game);

--- a/extension/twitchapi.js
+++ b/extension/twitchapi.js
@@ -19,6 +19,9 @@ module.exports = function (nodecg) {
         nodecg.listenFor('playTwitchAd',playTwitchAd);
 		accessTokenReplicant = nodecg.Replicant('twitchAccessToken', {persistent: false});
 		twitchChannelInfoReplicant = nodecg.Replicant('twitchChannelInfo', {persistent: false});
+		
+		// Twitch search to and fro
+		nodecg.listenFor('twitchGameSearch',twitch_GameSearch);
 
         app.get('/nodecg-speedcontrol/twitchlogin', function (req, res) {
             console.log("intercepted a message!");
@@ -42,6 +45,30 @@ module.exports = function (nodecg) {
 function twitch_Login() {
     var URL = twitch.getAuthorizationUrl();
     nodeCgExport.sendMessage('twitchLoginAuthorization',URL);
+}
+
+function twitch_GameSearch(searchQuery, callback) {
+	var replyData = '';
+
+	// use this by sending a nodecg.sendMessage('twitchGameSearch', QUERY, function(reply) {
+	twitch.searchGames({query: searchQuery, type:'suggest'}, function(err, body) {
+		if (err){
+             console.log("Error occurred in communication with twitch, look below");
+             console.log(err);
+		} else {
+			// set the reply replicant with the first result
+			if ((body.games[0] != undefined) && (body.games[0].name != null)) {
+				replyData = body.games[0].name;
+				console.log("First result on twitch for \""+ searchQuery + "\" was \""+ replyData + "\"");
+				} else {
+				// return nothing if no results
+				replyData = '';
+				console.log("No matches on twitch for \""+ searchQuery +"\"");
+			}
+		}
+		// Pass reply back to web browser
+		callback(replyData);
+	})
 }
 
 function twitch_LoginForwardCode(code) {


### PR DESCRIPTION
Speedrun.com and Twitch both handle searches slightly differently so match on different games. At the moment priority is given to Speedrun.com as that's the data we can manage and edit. Twitch is a backup mostly for games that don't use Speedrun.com at all - good example is Super Metroid.

I've run it through the current dataset for DHW with only a couple of misses that can be fixed by game names in schedule. It makes some assumptions. It makes a case insensitive but otherwise exact comparison to Speedrun.com. Like I said before - we have access to fix this data so it should be precise to begin with. When falling back to twitch it strips (words in parenthesis) and punctuation. Please install, test and watch console output to see how it performs.