### PR TITLE
(Re-)Added a callback for successful twitch ad initiations

### DIFF
--- a/extension/twitchapi.js
+++ b/extension/twitchapi.js
@@ -176,7 +176,7 @@ function playTwitchAd(data, callback) {
 			nodecg.log.info('Requested a Twitch ad be played.');
 			if (handleResponse(err, resp)) {
 				nodecg.log.info('Twitch ad started successfully.');
-				// nodecg.sendMessage('twitchAdStarted', {'duration':180});
+				nodecg.sendMessage('twitchAdStarted', {'duration':180});
 				if (callback) callback({successful: true, result: {duration: 180}}); // Calls back successfully.
 			}
 			else

--- a/extension/twitchapi.js
+++ b/extension/twitchapi.js
@@ -176,11 +176,11 @@ function playTwitchAd(data, callback) {
 			nodecg.log.info('Requested a Twitch ad be played.');
 			if (handleResponse(err, resp)) {
 				nodecg.log.info('Twitch ad started successfully.');
-				nodecg.sendMessage('twitchAdStarted', {'duration':180});
-				if (callback) callback(false); // Calls back successfully.
+				// nodecg.sendMessage('twitchAdStarted', {'duration':180});
+				if (callback) callback({successful: true, result: {duration: 180}}); // Calls back successfully.
 			}
 			else
-				if (callback) callback(true); // Call back with an error.
+				if (callback) callback({successful: false, error: err}); // Call back with an error.
 		});
 	});
 }

--- a/extension/twitchapi.js
+++ b/extension/twitchapi.js
@@ -176,7 +176,7 @@ function playTwitchAd(data, callback) {
 			nodecg.log.info('Requested a Twitch ad be played.');
 			if (handleResponse(err, resp)) {
 				nodecg.log.info('Twitch ad started successfully.');
-				//nodecg.sendMessage('twitchAdStarted');
+				nodecg.sendMessage('twitchAdStarted', {'duration':180});
 				if (callback) callback(false); // Calls back successfully.
 			}
 			else


### PR DESCRIPTION
In order to show the ad break durations on stream, we need to know when a twitch ad was successfully created. This change _should_ allow for that, however I have been unable to test it until now.