### PR TITLE
Replace deprecated chat_login permission

### DIFF
--- a/dashboard/StreamControlDashboard.js
+++ b/dashboard/StreamControlDashboard.js
@@ -17,7 +17,7 @@ $(function() {
 		$('#twitchAuthLink').show();
 		
 		// Change "Connect with Twitch" button link to be correct to the config settings.
-		$('#twitchAuthLink a').attr('href', 'https://api.twitch.tv/kraken/oauth2/authorize?client_id='+nodecg.bundleConfig.twitch.clientID+'&redirect_uri='+nodecg.bundleConfig.twitch.redirectURI+'&response_type=code&scope=channel_editor+user_read+chat_login+channel_commercial&force_verify=true');
+		$('#twitchAuthLink a').attr('href', 'https://api.twitch.tv/kraken/oauth2/authorize?client_id='+nodecg.bundleConfig.twitch.clientID+'&redirect_uri='+nodecg.bundleConfig.twitch.redirectURI+'&response_type=code&scope=channel_editor+user_read+chat:read+chat:edit+channel_commercial&force_verify=true');
 	}
 	
 	$enableTwitchSynchronizationRadios.controlgroup();


### PR DESCRIPTION
The "chat_login" scope permission was recently deprecated and new Twitch apps are not allowed to request this permission, so the Twitch authentication process gives a scope error.  This change replaces it with the new "chat:read" and "chat:edit" permissions of the new API, which allows the FFZ integration to work properly with newly created apps.