### PR TITLE
Fix Japanese localisation strings

### DIFF
--- a/src/dashboard/_misc/i18n.ts
+++ b/src/dashboard/_misc/i18n.ts
@@ -33,7 +33,7 @@ export default new VueI18n({
       gameTwitch: 'Twitchのゲームカテゴリー',
       players: 'プレイヤー',
       category: 'カテゴリー',
-      estimate: 'EST',
+      estimate: '予定タイム',
       system: '機種',
       region: 'リージョン',
       released: 'リリース日',


### PR DESCRIPTION
After consulting with other Japanese users, we decided that it would be better to translate "Estimate" into "予定タイム", so I create pull request.