### PR TITLE
Add speedcontrol-layouts and speedcontrol-tweetr to the list of supported bundles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ To easily install: `nodecg install speedcontrol/BUNDLE-NAME`
 - [speedcontrol-tiltify](https://github.com/speedcontrol/speedcontrol-tiltify): Adds a frequently updating donation total amount for a Tiltify campaign you can use in layouts.
 - [speedcontrol-srcomtracker](https://github.com/speedcontrol/speedcontrol-srcomtracker): Adds frequently updating donation total/goals/bidwars and messages for new donations for a marathon on [speedrun.com](https://www.speedrun.com) if they are enabled, that you can use in your layouts.
 - [speedcontrol-flagcarrier](https://github.com/speedcontrol/speedcontrol-flagcarrier): Adds a server and replicants that can receive requests from ESA's [FlagCarrier android app](https://play.google.com/store/apps/details?id=de.oromit.flagcarrier) so this information can be used in your layouts.
+- [speedcontrol-layouts](https://github.com/nicnacnic/speedcontrol-layouts): A base pack of layouts for anyone to customize. Includes Tiltify support for donation totals, incentives, and prizes, layout Photoshop files, and detailed documentation for all your customization needs.
 
 
 ## Where has this bundle been used before?

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To easily install: `nodecg install speedcontrol/BUNDLE-NAME`
 - [speedcontrol-srcomtracker](https://github.com/speedcontrol/speedcontrol-srcomtracker): Adds frequently updating donation total/goals/bidwars and messages for new donations for a marathon on [speedrun.com](https://www.speedrun.com) if they are enabled, that you can use in your layouts.
 - [speedcontrol-flagcarrier](https://github.com/speedcontrol/speedcontrol-flagcarrier): Adds a server and replicants that can receive requests from ESA's [FlagCarrier android app](https://play.google.com/store/apps/details?id=de.oromit.flagcarrier) so this information can be used in your layouts.
 - [speedcontrol-layouts](https://github.com/nicnacnic/speedcontrol-layouts): A base pack of layouts for anyone to customize. Includes Tiltify support for donation totals, incentives, and prizes, layout Photoshop files, and detailed documentation for all your customization needs.
+- [speedcontrol-tweetr](https://github.com/nicnacnic/speedcontrol-tweetr): Control Twitter right from your NodeCG dashboard!
 
 
 ## Where has this bundle been used before?


### PR DESCRIPTION
Pretty much what the title says. speedcontrol-layouts is a support bundle that adds a bunch of graphics to speedcontrol, while speedcontrol-tweetr allows you to post and schedule tweets from the dashboard.

https://github.com/nicnacnic/speedcontrol-layouts
https://github.com/nicnacnic/speedcontrol-tweetr