### PR TITLE
Fixed an issue with the Twitch Control Dashboard not updating the FFZ featured channel when updating manually

### DIFF
--- a/src/dashboard/twitch-control/main.vue
+++ b/src/dashboard/twitch-control/main.vue
@@ -264,6 +264,9 @@ export default class extends Vue {
   }
 
   async updateChannelInfo(): Promise<void> {
+    //temporary as this.users get refreshed inbetween updating twitch and ffz
+    var usersTmp = this.users;
+
     try {
       const noTwitchGame = await nodecg.sendMessage('twitchUpdateChannelInfo', {
         status: this.title,
@@ -282,7 +285,7 @@ export default class extends Vue {
       try {
         await nodecg.sendMessage(
           'updateFeaturedChannels',
-          this.users.replace(/\s/g, '').split(',').filter(Boolean),
+          usersTmp.replace(/\s/g, '').split(',').filter(Boolean)
         );
       } catch (err) {
         // catch


### PR DESCRIPTION
After sending the 'twitchUpdateChannelInfo' message, onChannelInfoChange() is triggered and updateInputs() reset both title game and users before users is used to send the 'updateFeaturedChannels' message