### PR TITLE
Display pronouns next to runner name

### DIFF
--- a/src/dashboard/_misc/components/RunList/RunPanel.vue
+++ b/src/dashboard/_misc/components/RunList/RunPanel.vue
@@ -132,7 +132,7 @@ export default class extends Vue {
   get playerStr(): string {
     return this.runData.teams.map((team) => (
       `${team.name ? `${team.name}:` : ''}
-      ${team.players.map((player) => player.name).join(', ')}`
+      ${team.players.map((player) => player.pronouns ? `${player.name} [${player.pronouns}]` : player.name).join(', ')}`
     )).join(' vs. ');
   }
 


### PR DESCRIPTION
Currently pronouns can be found in the run editor but not in the run player. Putting it on the run player means that run management volunteers can easily see the runner's pronouns to verify that they are correct.

![image](https://user-images.githubusercontent.com/19513845/132127202-65faaaa9-37ee-41a7-b2eb-a15428fe7ab0.png)
