### PR TITLE
Use custom setup block label if set on oengus

### DIFF
--- a/src/extension/oengus-import.ts
+++ b/src/extension/oengus-import.ts
@@ -130,7 +130,7 @@ async function importSchedule(marathonShort: string, useJapanese: boolean): Prom
       runData.setupTimeS = toSeconds(parsedSetup);
       if (line.setupBlock) {
         // Game name set to "Setup" if the line is a setup block.
-        runData.game = 'Setup';
+        runData.game = line.setupBlockText || 'Setup';
         // Estimate for a setup block will be the setup time instead.
         runData.estimate = runData.setupTime;
         runData.estimateS = runData.setupTimeS;

--- a/src/extension/oengus-import.ts
+++ b/src/extension/oengus-import.ts
@@ -131,6 +131,7 @@ async function importSchedule(marathonShort: string, useJapanese: boolean): Prom
       if (line.setupBlock) {
         // Game name set to "Setup" if the line is a setup block.
         runData.game = line.setupBlockText || 'Setup';
+        runData.gameTwitch = 'Just Chatting';
         // Estimate for a setup block will be the setup time instead.
         runData.estimate = runData.setupTime;
         runData.estimateS = runData.setupTimeS;


### PR DESCRIPTION
Oengus allows schedulers to set a custom name for the setup block text, speedcontrol should adhere to this value if it is set by the oengus end user