### PR TITLE
Update twitch after replicant change

### DIFF
--- a/src/extension/run-control.ts
+++ b/src/extension/run-control.ts
@@ -111,10 +111,10 @@ async function changeActiveRun(id?: string): Promise<boolean> {
     if (!runData) {
       throw new Error(`Run with ID ${id} was not found`);
     } else {
-      const noTwitchGame = await updateTwitchInformation(runData);
       runDataActiveRun.value = clone(runData);
       to(resetTimer(true));
       nodecg.log.debug(`[Run Control] Active run changed to ${id}`);
+      const noTwitchGame = await updateTwitchInformation(runData);
       return noTwitchGame;
     }
   } catch (err) {


### PR DESCRIPTION
There have been times when there has been substantial delay when switching games due to slow internet or a slow response time. In the events I run we try to hide the game switch during a transition, however this breaks when the bundle waits for twitch's response before updating the replicant.